### PR TITLE
Don't require OS to have media and ptables

### DIFF
--- a/foreman_operatingsystem.py
+++ b/foreman_operatingsystem.py
@@ -169,9 +169,11 @@ def ensure():
     data['description'] = module.params['description']
     data['family'] = module.params['family']
     data['minor'] = module.params['minor']
-    data['media'] = get_resources(resource_type='media', resource_specs=module.params['media'])
+    if module.params['media']:
+        data['media'] = get_resources(resource_type='media', resource_specs=module.params['media'])
 
-    data['ptables'] = get_resources(resource_type='ptables', resource_specs=module.params['ptables'])
+    if module.params['ptables']:
+        data['ptables'] = get_resources(resource_type='ptables', resource_specs=module.params['ptables'])
     data['release_name'] = module.params['release_name']
 
     if not os:


### PR DESCRIPTION
They're not needed with image based installs