### PR TITLE
foreman_compute_attribute: Set default for ssl

### DIFF
--- a/foreman_compute_attribute.py
+++ b/foreman_compute_attribute.py
@@ -134,7 +134,7 @@ def main():
             foreman_port=dict(type='str', Default='443'),
             foreman_user=dict(type='str', required=True),
             foreman_pass=dict(type='str', required=True, no_log=True),
-            foreman_ssl=dict(type='bool', required=False)
+            foreman_ssl=dict(type='bool', required=False, default=True)
         ),
     )
 


### PR DESCRIPTION
otherwise we fail if we don't set foreman_ssl attribute.