### PR TITLE
library: Allow to update compute resources

### DIFF
--- a/foreman_compute_resource.py
+++ b/foreman_compute_resource.py
@@ -182,8 +182,6 @@ def ensure(module):
                 module.fail_json(msg='Could not create compute resource: {0}'.format(e.message))
             return True, compute_resource
 
-        return False, compute_resource
-
         if not all(data.get(key, None) == compute_resource.get(key, None) for key in params):
             try:
                 compute_resource = theforeman.update_compute_resource(id=compute_resource.get('id'), data=data)


### PR DESCRIPTION
This is not perfect. We always display changes since the Foreman API
doesn't return the password but we have one and so the comparison fails.
But it's far better than issuing "no changes required" as we do right
now.