### PR TITLE
Fix imports

### DIFF
--- a/foreman_architecture.py
+++ b/foreman_architecture.py
@@ -134,7 +134,7 @@ def main():
     module.exit_json(changed=changed, architecture=arch)
 
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/foreman_compute_attribute.py
+++ b/foreman_compute_attribute.py
@@ -145,7 +145,7 @@ def main():
     module.exit_json(changed=changed, compute_attribute=compute_attribute)
 
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/foreman_compute_profile.py
+++ b/foreman_compute_profile.py
@@ -135,7 +135,7 @@ def main():
     module.exit_json(changed=changed, compute_profile=compute_profile)
 
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/foreman_compute_resource.py
+++ b/foreman_compute_resource.py
@@ -228,7 +228,7 @@ def main():
     module.exit_json(changed=changed, compute_resource=compute_resource)
 
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/foreman_config_template.py
+++ b/foreman_config_template.py
@@ -268,7 +268,7 @@ def main():
     module.exit_json(changed=changed, config_template=config_template)
 
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/foreman_domain.py
+++ b/foreman_domain.py
@@ -186,7 +186,7 @@ def main():
     module.exit_json(changed=changed, domain=domain)
 
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/foreman_environment.py
+++ b/foreman_environment.py
@@ -134,7 +134,7 @@ def main():
     module.exit_json(changed=changed, environment=env)
 
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/foreman_host.py
+++ b/foreman_host.py
@@ -488,7 +488,7 @@ def main():
     module.exit_json(changed=changed, host=host)
 
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/foreman_image.py
+++ b/foreman_image.py
@@ -223,7 +223,7 @@ def main():
     module.exit_json(changed=changed, image=image)
 
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/foreman_ldap.py
+++ b/foreman_ldap.py
@@ -182,7 +182,7 @@ def main():
     module.exit_json(changed=changed, name=module.params['name'])
 
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/foreman_location.py
+++ b/foreman_location.py
@@ -161,7 +161,7 @@ def main():
     module.exit_json(changed=changed, name=module.params['name'])
 
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/foreman_medium.py
+++ b/foreman_medium.py
@@ -164,7 +164,7 @@ def main():
     module.exit_json(changed=changed, medium=medium)
 
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/foreman_operatingsystem.py
+++ b/foreman_operatingsystem.py
@@ -243,7 +243,7 @@ def main():
     module.exit_json(changed=changed, operatingsystem=os)
 
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/foreman_organization.py
+++ b/foreman_organization.py
@@ -123,7 +123,7 @@ def main():
     module.exit_json(changed=changed, name=module.params['name'])
 
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/foreman_os_default_template.py
+++ b/foreman_os_default_template.py
@@ -182,7 +182,7 @@ def main():
     module.exit_json(changed=changed, os_default_template=os_default_template)
 
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/foreman_ptable.py
+++ b/foreman_ptable.py
@@ -173,7 +173,7 @@ def main():
     module.exit_json(changed=changed, ptable=ptable)
 
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/foreman_realm.py
+++ b/foreman_realm.py
@@ -182,7 +182,7 @@ def main():
     module.exit_json(changed=changed, realm=realm)
 
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/foreman_role.py
+++ b/foreman_role.py
@@ -136,7 +136,7 @@ def main():
     module.exit_json(changed=changed, role=role)
 
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/foreman_smart_proxy.py
+++ b/foreman_smart_proxy.py
@@ -140,7 +140,7 @@ def main():
     module.exit_json(changed=changed, smart_proxy=smart_proxy)
 
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/foreman_subnet.py
+++ b/foreman_subnet.py
@@ -270,7 +270,7 @@ def main():
     module.exit_json(changed=changed, subnet=subnet)
 
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/foreman_user.py
+++ b/foreman_user.py
@@ -232,7 +232,7 @@ def main():
     module.exit_json(changed=changed, user=user)
 
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Ansible wants

  from ansible.module_utils.basic import *

otherwise it aborts with:

  fatal: [foo.example.com]: FAILED! => {"failed": true, "msg": "ERROR! error importing module in /home/godiug/infra20/ansible-foreman-resources/library/ansible-module-foreman/foreman_image.py, expecting format like 'from ansible.module_utils.basic import *'"}

on Ansible 2.0 at least.

See

   http://docs.ansible.com/ansible/dev_guide/developing_program_flow_modules.html#module-replacer

for details.