### PR TITLE
Clean all media feature

### DIFF
--- a/foreman_medium.py
+++ b/foreman_medium.py
@@ -111,20 +111,14 @@ def ensure(module):
     data = {'name': name}
 
 
-    if name == '*' :
+    if name == '*' and state == 'absent':
         try:
             all_media_list = theforeman.get_resources(resource_type=MEDIA)
+            for element in all_media_list:
+                theforeman.delete_medium(id=element.get('id'))
             return True, all_media_list
         except ForemanError as e:
-            module.fail_json(msg='Could not find media: {0}'.format(e.message))
-
-    #     # try:
-    #     #     for element in all_media_list:
-    #     #         theforeman.delete_medium(id=element.get('id'))
-    #     #         return True, element    
-    #     # except ForemanError as e:
-    #     #     module.fail_json(msg='Could not delete media: {0}'.format(e.message))    
-
+            module.fail_json(msg='Error in deleting all existing media: {0}'.format(e.message))
 
     try:
         medium = theforeman.search_medium(data=data)

--- a/foreman_medium.py
+++ b/foreman_medium.py
@@ -110,6 +110,22 @@ def ensure(module):
 
     data = {'name': name}
 
+
+    if name == '*' :
+        try:
+            all_media_list = theforeman.get_resources(resource_type=MEDIA)
+            return True, all_media_list
+        except ForemanError as e:
+            module.fail_json(msg='Could not find media: {0}'.format(e.message))
+
+    #     # try:
+    #     #     for element in all_media_list:
+    #     #         theforeman.delete_medium(id=element.get('id'))
+    #     #         return True, element    
+    #     # except ForemanError as e:
+    #     #     module.fail_json(msg='Could not delete media: {0}'.format(e.message))    
+
+
     try:
         medium = theforeman.search_medium(data=data)
     except ForemanError as e:
@@ -140,6 +156,7 @@ def ensure(module):
                 module.fail_json(msg='Could not update medium: {0}'.format(e.message))
 
     return False, medium
+
 
 
 def main():

--- a/foreman_medium.py
+++ b/foreman_medium.py
@@ -25,7 +25,7 @@ description:
 options:
   name:
     description:
-    - Medium name
+    - Medium name, a combination of name '*' and state 'absent' can be used to clean up, by deleting all present media
     required: true
   path:
     description:
@@ -37,7 +37,7 @@ options:
     required: false
   state:
     description:
-    - Medium state
+    - Medium state, , a combination of name '*' and state 'absent' can be used to clean up, by deleting all present media
     required: false
     default: 'present'
     choices: ['present', 'absent']


### PR DESCRIPTION
Adding a code-block to foreman_medium.py to be able to clean all existing media from a foreman-environment.
The cleaning can be achieved by choosing '*' as the medium name and state 'absent'