### PR TITLE
config_template: drop template_kind_id on updates

### DIFF
--- a/foreman_config_template.py
+++ b/foreman_config_template.py
@@ -232,6 +232,7 @@ def ensure():
                 not equal_dict_lists(l1=data.get('operatingsystems', None),
                                      l2=config_template.get('operatingsystems', None))):
             try:
+                del data['template_kind_id']
                 config_template = theforeman.update_config_template(id=config_template.get('id'), data=data)
                 return True, config_template
             except ForemanError as e:


### PR DESCRIPTION
This will prevent us from updating the template_kind but otherwise we
fail every update with:

fatal: [foo -> localhost]: FAILED! =>
{"changed": false, "failed": true, "msg": "Could not update config
template: PG::UndefinedFunction: ERROR:  operator does not exist:
character varying = integer\nLINE 1: ...mplate_kinds\".\"id\" = 5 OR
\"template_kinds\".\"name\" = 5)) ORDE...\n ^\nHINT:  No operator
matches the given name and argument type(s). You might need to add
explicit type casts.\n: SELECT \"template_kinds\".* FROM
\"template_kinds\"  WHERE ((\"template_kinds\".\"id\" = 5 OR
\"template_kinds\".\"name\" = 5)) ORDER BY CASE WHEN
\"template_kinds\".\"name\" = 5 THEN 1 ELSE 0 END LIMIT 1"}

this is a foreman bug in the end but otherwise updates break completely
over here.

Might be debatable so putting this into a different PR