### PR TITLE
Set a proper default for admin

### DIFF
--- a/foreman_user.py
+++ b/foreman_user.py
@@ -208,7 +208,7 @@ def ensure(module):
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            admin=dict(type='str', required=False),
+            admin=dict(type='str', required=False, default=False),
             auth_source_name=dict(type='str', default='Internal', aliases=['auth']),
             login=dict(type='str', required=True, aliases=['name']),
             firstname=dict(type='str', required=False),


### PR DESCRIPTION
Without this newer foreman will fail since it has a non-null constraint
on the admin column.