### PR TITLE
Allow for defining of network interfaces in foreman_host provisioning.

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,23 @@ or
     state: absent
 ...
 ```
+### Host with network interfaces
+```yaml
+- name: Ensure Host
+  foreman_host:
+    name: ansible-host-04
+    state: present
+    .
+    .
+    interfaces:
+      - ip: 10.11.12.123
+        mac: 00:21:f6:16:e4:2e
+        subnet: "Dev Network"
+      - ip: 10.11.12.124
+        mac: 00:21:f6:42:52:91
+        subnet: "Dev Network"
+    ...
+```
 ## Hostgroup
 ```yaml
 - name: Ensure Hostgroup


### PR DESCRIPTION
Hi @Nosmoht, thanks for this ansible module!
This change is to allow for one or more network interfaces when defining foreman_host (see the change in README.md for a basic example). Only introducing new `interfaces` argument to foreman_host, not changing any existing functionality. Thanks