### PR TITLE
host interfaces: support subnet by name for both interfaces and inter…

### DIFF
--- a/foreman_host.py
+++ b/foreman_host.py
@@ -217,6 +217,17 @@ def filter_host(h):
     return filtered
 
 
+def resolve_subnet_names(interfaces, theforeman):
+    for iface in interfaces:
+        # get subnet id if subnet name specified
+        iface_subnet_name = iface.pop('subnet', None)
+        if iface_subnet_name:
+            iface_subnet = get_resource(resource_type=SUBNET,
+                                        resource_func=theforeman.search_subnet,
+                                        resource_name=iface_subnet_name)
+            iface['subnet_id'] = iface_subnet.get('id')
+
+
 def ensure():
     changed = False
     name = module.params['name']
@@ -254,7 +265,6 @@ def ensure():
     content_source_name = module.params['content_source']
     content_view_name = module.params['content_view']
     lifecycle_environment_name = module.params['lifecycle_environment']
-    interfaces_attributes = module.params['interfaces_attributes'] 
 
     foreman_host = module.params['foreman_host']
     foreman_port = module.params['foreman_port']
@@ -490,6 +500,7 @@ def ensure():
 
     # interface attributes
     if interfaces_attributes:
+        resolve_subnet_names(interfaces_attributes, theforeman)
         data['interfaces_attributes'] = interfaces_attributes
 
     if not host and state == 'present':
@@ -575,6 +586,7 @@ def ensure():
 
     # Network Interfaces
     if interfaces:
+        resolve_subnet_names(interfaces, theforeman)
         try:
             host_interfaces = theforeman.get_resource('hosts', host_id, component='interfaces').get('results') or []
         except ForemanError as e:
@@ -601,14 +613,6 @@ def ensure():
         # Create/update interfaces
         for iface in interfaces:
             interface_ip = iface.get('ip')
-
-            # get subnet id if subnet name specified
-            iface_subnet_name = iface.pop('subnet', None)
-            if iface_subnet_name:
-                iface_subnet = get_resource(resource_type=SUBNET,
-                                            resource_func=theforeman.search_subnet,
-                                            resource_name=iface_subnet_name)
-                iface['subnet_id'] = iface_subnet.get('id')
 
             if not has_primary:
                 # No interface marked as primary.


### PR DESCRIPTION
…faces_attributes

With this change, specifying an interface subnet by its name
will be possible not only in 'interfaces' but also in
'interfaces_attributes'.