### PR TITLE
Templates operatingsystems update fix

### DIFF
--- a/foreman_config_template.py
+++ b/foreman_config_template.py
@@ -235,7 +235,7 @@ def ensure():
             if res:
                 data['template_kind_id'] = res[0]["id"]
 
-        if not snippet:
+        if not snippet and operatingsystems is not None:
             data['operatingsystems'] = get_resources(resource_type='operatingsystem',
                                                      resource_func=theforeman.search_operatingsystem,
                                                      resource_specs=operatingsystems,

--- a/foreman_config_template.py
+++ b/foreman_config_template.py
@@ -135,12 +135,9 @@ except ImportError as e:
 def templates_equal(data, config_template):
     comparable_keys = set(data.keys()).intersection(set(
         ['locked', 'snippet', 'template', 'audit_comment', 'template_kind_id']))
-    comparable_arrays = set(data.keys()).intersection(set(['operatingsystems']))
     if not all(data.get(key, None) == config_template.get(key, None) for key in comparable_keys):
         return False
-    if not all(equal_dict_lists(l1=data.get(key, None),
-                                l2=config_template.get(key, None),
-                                compare_key='title') for key in comparable_arrays):
+    if not operatingsystems_equal(data, config_template):
         return False
     if not organizations_equal(data, config_template):
         return False
@@ -228,6 +225,8 @@ def ensure():
             data['organization_ids'] = get_organization_ids(module, theforeman, organizations)
         if locations is not None:
             data['location_ids'] = get_location_ids(module, theforeman, locations)
+        if operatingsystems is not None:
+            data['operatingsystem_ids'] = get_operatingsystem_ids(module, theforeman, operatingsystems)
 
         if template_kind_name:
             res = get_resources(resource_type='template_kinds',

--- a/module_utils/foreman_utils.py
+++ b/module_utils/foreman_utils.py
@@ -29,11 +29,11 @@ def dict_list_to_list(alist, key):
     return result
 
 
-def get_resource_ids(resource_type, module, theforeman, resource_names):
+def get_resource_ids(resource_type, module, theforeman, resource_names, search_field='name'):
     result = []
     for i in range(0, len(resource_names)):
         try:
-            resource = theforeman.search_resource(resource_type=resource_type, data={'name': resource_names[i]})
+            resource = theforeman.search_resource(resource_type=resource_type, data={search_field: resource_names[i]})
             if not resource:
                 module.fail_json(msg='Could not find {type} {name}'.format(
                     type=resource_type,name=resource_names[i]))
@@ -48,7 +48,7 @@ def get_organization_ids(module, theforeman, organizations):
 def get_location_ids(module, theforeman, locations):
     return get_resource_ids(LOCATIONS, module, theforeman, locations)
 def get_operatingsystem_ids(module, theforeman, operating_systems):
-    return get_resource_ids(OPERATINGSYSTEMS, module, theforeman, operating_systems)
+    return get_resource_ids(OPERATINGSYSTEMS, module, theforeman, operating_systems, search_field='title')
 
 
 def organizations_equal(data, resource):


### PR DESCRIPTION
'title' field (composite of name, major and minor ver) uniquely identifies Operating Systems. Use it in get_operatingsystem_ids.

Fix config templates 'operatingsystems' updates (similar to organizations and locations - need to send 'operatingsystem_ids' to Foreman).

Rework equality check of config template operating systems to only compare and trigger update if provided (otherwise existing template operating systems deleted when not provided in playbook).