### PR TITLE
foreman_compute_attribute module fails when running in Python 3

### DIFF
--- a/foreman_compute_attribute.py
+++ b/foreman_compute_attribute.py
@@ -101,7 +101,12 @@ def ensure(module):
                                                           compute_profile_id=compute_profile.get('id'))
 
     if compute_attributes:
-        compute_attribute = compute_attributes[0]
+        try:
+            # Python 2
+            compute_attribute = compute_attributes[0]
+        except TypeError:
+            # Python 3
+            compute_attribute = next(compute_attributes)
     else:
         compute_attribute = None
 


### PR DESCRIPTION
When running the foreman_compute_attribute in Python 3 the module fails with error `TypeError: 'filter' object is not subscriptable`.

This commit will allow the module to run with both Python 2 and 3. 